### PR TITLE
Tests for CR parser

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -878,7 +878,7 @@ Style/RedundantSelf:
   Enabled: true
 
 Style/RegexpLiteral:
-  Enabled: true
+  Enabled: false
   EnforcedStyle: slashes
   AllowInnerSlashes: false
 

--- a/lib/bestiary/parsers/cr.rb
+++ b/lib/bestiary/parsers/cr.rb
@@ -1,10 +1,9 @@
 class Bestiary::Parsers::Cr
   def self.perform(creature)
-    bold_elements = creature.css('b')
-    bold_elements.each do |bold|
-      if bold.text.match('CR ')
-        cr_string = bold.text.gsub(/[^\d]/, '')
-        return cr_string.to_i
+    stat_elements = creature.css('p')
+    stat_elements.each do |stat|
+      if stat.text.match('CR ')
+        return stat.text.gsub(/[^\d\/]/, '')
       end
     end
 

--- a/lib/bestiary/parsers/cr.rb
+++ b/lib/bestiary/parsers/cr.rb
@@ -6,7 +6,6 @@ class Bestiary::Parsers::Cr
         return stat.text.gsub(/[^\d\/]/, '')
       end
     end
-
-    raise 'could not parse CR'
+    'not found'
   end
 end

--- a/spec/parsers/cr_parser_spec.rb
+++ b/spec/parsers/cr_parser_spec.rb
@@ -1,0 +1,19 @@
+module Bestiary
+  RSpec.describe Parsers::Cr do
+    describe 'perform' do
+      it 'returns the CR value from the creature' do
+        html = cr_html('1/2')
+        dom = parse_html(html)
+
+        result = Parsers::Cr.perform(dom)
+
+        expect(result).to eq('1/2')
+      end
+    end
+
+    def cr_html(text)
+      %(<p class="stat-block-title">Giant Flea <span class="stat-block-cr">
+      CR #{text}</span></p>)
+    end
+  end
+end

--- a/spec/parsers/cr_parser_spec.rb
+++ b/spec/parsers/cr_parser_spec.rb
@@ -11,6 +11,16 @@ module Bestiary
       end
     end
 
+    it 'returns "not found" if it cant parse the CR' do
+      html = %(<p class="stat-block-title">Giant Flea
+               <span class="stat-block-cr">foo</span></p>)
+      dom = parse_html(html)
+
+      result = Parsers::Cr.perform(dom)
+
+      expect(result).to eq('not found')
+    end
+
     def cr_html(text)
       %(<p class="stat-block-title">Giant Flea <span class="stat-block-cr">
       CR #{text}</span></p>)


### PR DESCRIPTION
Two notable changes:

First, the CR parser now also returns "not found" when it can't find anything, similar to the alignment parser.

Also, I turned off the `Style/RegexpLiteral` rubocop rule. Even if this was set to the `slashes` option, it was asking me to convert to the percent literal version.
