### PR TITLE
Refactor name parser

### DIFF
--- a/lib/bestiary/parsers/name.rb
+++ b/lib/bestiary/parsers/name.rb
@@ -1,6 +1,20 @@
 class Bestiary::Parsers::Name
+  attr_reader :creature
+
   def self.perform(creature)
-    name_group = creature.at('h1')
-    name_group.children.first.text.strip
+    new(creature).perform
+  end
+
+  def initialize(creature)
+    @creature = creature
+  end
+
+  def perform
+    name_from_headings
+  end
+
+  def name_from_headings
+    heading = creature.css('h1, h2').first
+    heading.text.strip
   end
 end

--- a/lib/bestiary/parsers/name.rb
+++ b/lib/bestiary/parsers/name.rb
@@ -10,11 +10,27 @@ class Bestiary::Parsers::Name
   end
 
   def perform
-    name_from_headings
+    name = name_from_headings
+
+    if last_name_first?(name)
+      switch_names(name)
+    else
+      name
+    end
   end
 
   def name_from_headings
     heading = creature.css('h1, h2').first
     heading.text.strip
+  end
+
+  def last_name_first?(name)
+    name.include?(', ')
+  end
+
+  def switch_names(name)
+    parts = name.split(', ')
+    switched = [parts.pop] + parts
+    switched.join(' ')
   end
 end

--- a/lib/bestiary/parsers/name.rb
+++ b/lib/bestiary/parsers/name.rb
@@ -10,7 +10,12 @@ class Bestiary::Parsers::Name
   end
 
   def perform
-    name = name_from_headings
+    name = ''
+    if headings?
+      name = name_from_headings
+    else
+      name = name_from_stats
+    end
 
     if last_name_first?(name)
       switch_names(name)
@@ -19,9 +24,27 @@ class Bestiary::Parsers::Name
     end
   end
 
+  def headings?
+    !creature.css('h1, h2').empty?
+  end
+
   def name_from_headings
     heading = creature.css('h1, h2').first
     heading.text.strip
+  end
+
+  def name_from_stats
+    stats = creature.css('p')
+    stats.each do |stat|
+      if stat.text.include?('CR')
+        return name_from_stat(stat)
+      end
+    end
+  end
+
+  def name_from_stat(stat)
+    title_parts = stat.parent.text.split(' CR')
+    title_parts.first.strip
   end
 
   def last_name_first?(name)

--- a/spec/parsers/name_parser_spec.rb
+++ b/spec/parsers/name_parser_spec.rb
@@ -25,6 +25,21 @@ module Bestiary
           end
         end
       end
+
+      context 'with no heading' do
+        context 'in standard first last name order' do
+          it 'returns the creature name' do
+            name = 'Violet Fungus'
+            html = %(<p class="stat-block-title"><b>#{name} <span
+                     class="stat-block-cr">CR 3</span></b></p>)
+            dom = parse_html(html)
+
+            result = Parsers::Name.perform(dom)
+
+            expect(result).to eq(name)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/parsers/name_parser_spec.rb
+++ b/spec/parsers/name_parser_spec.rb
@@ -13,6 +13,17 @@ module Bestiary
             expect(result).to eq(name)
           end
         end
+
+        context 'in last-name-first order' do
+          it 'returns the creature name' do
+            html = %(<h1 id="demon-balor">Demon, Balor</h1>)
+            dom = parse_html(html)
+
+            result = Parsers::Name.perform(dom)
+
+            expect(result).to eq('Balor Demon')
+          end
+        end
       end
     end
   end

--- a/spec/parsers/name_parser_spec.rb
+++ b/spec/parsers/name_parser_spec.rb
@@ -1,0 +1,19 @@
+module Bestiary
+  RSpec.describe Parsers::Name do
+    describe '.perform' do
+      context 'with a normal name' do
+        context 'in standard first last name order' do
+          it 'returns the creature name' do
+            name = 'Basilisk'
+            html = %(<h1 id="#{name.downcase}">#{name}</h1>)
+            dom = parse_html(html)
+
+            result = Parsers::Name.perform(dom)
+
+            expect(result).to eq(name)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The name parser now looks at headings and the same stat blog as `CR`. It also detects when names are reversed like `Demon, Balor` instead of `Balor Demon` and corrects those.
