### PR TITLE
Type parser

### DIFF
--- a/lib/bestiary/attributes.rb
+++ b/lib/bestiary/attributes.rb
@@ -4,3 +4,4 @@ end
 require 'bestiary/attributes/basic'
 require 'bestiary/attributes/sense'
 require 'bestiary/attributes/aura'
+require 'bestiary/attributes/type'

--- a/lib/bestiary/attributes/type.rb
+++ b/lib/bestiary/attributes/type.rb
@@ -1,0 +1,12 @@
+class Bestiary::Attributes::Type
+  attr_reader :title, :subtypes
+
+  def initialize(title:, subtypes: [])
+    @title = title
+    @subtypes = subtypes
+  end
+
+  def ==(other)
+    (title == other.title && subtypes == other.subtypes)
+  end
+end

--- a/lib/bestiary/parsers/type.rb
+++ b/lib/bestiary/parsers/type.rb
@@ -133,7 +133,8 @@ class Bestiary::Parsers::Type
     types = []
     text = parent_element.text
     SUBTYPES.each do |subtype|
-      if text.include?(subtype)
+      regexp = %r{\b#{subtype}\b}
+      if text.match(regexp)
         types << subtype
       end
     end

--- a/lib/bestiary/parsers/type.rb
+++ b/lib/bestiary/parsers/type.rb
@@ -40,13 +40,12 @@ class Bestiary::Parsers::Type
     end
   end
 
+  def primary_type
+    text = parent_element.text
     type_regexp = Regexp.union(TYPES)
-    stats = creature.css('p.stat-block-1')
-    stats.each do |stat|
-      match = stat.text.match(type_regexp)
-      if match
-        return stat
-      end
+    match = text.match(type_regexp)
+    if match
+      return match[0]
     end
   end
 

--- a/lib/bestiary/parsers/type.rb
+++ b/lib/bestiary/parsers/type.rb
@@ -15,11 +15,22 @@ class Bestiary::Parsers::Type
     'vermin'
   ].freeze
 
+  attr_reader :creature
+
   def self.perform(creature)
-    new.perform(creature)
+    new(creature).perform
   end
 
-  def perform(creature)
+  def initialize(creature)
+    @creature = creature
+  end
+
+  def perform
+    title = primary_type
+    Bestiary::Attributes::Type.new(title: title)
+  end
+
+  def primary_type
     type_regexp = Regexp.union(TYPES)
     stats = creature.css('p.stat-block-1')
     stats.each do |stat|

--- a/lib/bestiary/parsers/type.rb
+++ b/lib/bestiary/parsers/type.rb
@@ -30,6 +30,26 @@ class Bestiary::Parsers::Type
     Bestiary::Attributes::Type.new(title: title)
   end
 
+  def parent_element
+    @parent_element ||= begin
+      type_regexp = Regexp.union(TYPES)
+      stats = creature.css('p.stat-block-1')
+      stats.detect do |stat|
+        !stat.text.match(type_regexp).nil?
+      end
+    end
+  end
+
+    type_regexp = Regexp.union(TYPES)
+    stats = creature.css('p.stat-block-1')
+    stats.each do |stat|
+      match = stat.text.match(type_regexp)
+      if match
+        return stat
+      end
+    end
+  end
+
   def primary_type
     type_regexp = Regexp.union(TYPES)
     stats = creature.css('p.stat-block-1')

--- a/lib/bestiary/parsers/type.rb
+++ b/lib/bestiary/parsers/type.rb
@@ -105,9 +105,7 @@ class Bestiary::Parsers::Type
   end
 
   def perform
-    title = primary_type
-    subtypes
-    Bestiary::Attributes::Type.new(title: title, subtypes: subtypes)
+    Bestiary::Attributes::Type.new(title: primary_type, subtypes: subtypes)
   end
 
   def parent_element

--- a/lib/bestiary/parsers/type.rb
+++ b/lib/bestiary/parsers/type.rb
@@ -15,6 +15,85 @@ class Bestiary::Parsers::Type
     'vermin'
   ].freeze
 
+  SUBTYPES = [
+    'adlet',
+    'aeon',
+    'aether',
+    'agathion',
+    'air',
+    'android',
+    'angel',
+    'aquatic',
+    'archon',
+    'asura',
+    'augmented',
+    'azata',
+    'behemoth',
+    'catfolk',
+    'changeling',
+    'chaotic',
+    'clockwork',
+    'cold',
+    'colossus',
+    'daemon',
+    'dark folk',
+    'deep one',
+    'demodand',
+    'demon',
+    'devil',
+    'div',
+    'dwarf',
+    'earth',
+    'elemental',
+    'elf',
+    'evil',
+    'extraplanar',
+    'fire',
+    'giant',
+    'gnome',
+    'goblinoid',
+    'good',
+    'gray',
+    'great old one',
+    'grippli',
+    'halfling',
+    'human',
+    'incorporeal',
+    'inevitable',
+    'kaiju',
+    'kami',
+    'kasatha',
+    'kitsune',
+    'kyton',
+    'lawful',
+    'leshy',
+    'manasaputra',
+    'mythic',
+    'native',
+    'nightshade',
+    'oni',
+    'orc',
+    'phantom',
+    'protean',
+    'psychopomp',
+    'qlippoth',
+    'rakshasa',
+    'ratfolk',
+    'reptilian',
+    'robot',
+    'sahkil',
+    'samsaran',
+    'sasquatch',
+    'shapechanger',
+    'skinwalker',
+    'swarm',
+    'udaeus',
+    'vanara',
+    'vishkanya',
+    'water',
+    'wayang'
+  ].freeze
+
   attr_reader :creature
 
   def self.perform(creature)
@@ -27,7 +106,8 @@ class Bestiary::Parsers::Type
 
   def perform
     title = primary_type
-    Bestiary::Attributes::Type.new(title: title)
+    subtypes
+    Bestiary::Attributes::Type.new(title: title, subtypes: subtypes)
   end
 
   def parent_element
@@ -49,14 +129,15 @@ class Bestiary::Parsers::Type
     end
   end
 
-  def primary_type
-    type_regexp = Regexp.union(TYPES)
-    stats = creature.css('p.stat-block-1')
-    stats.each do |stat|
-      match = stat.text.match(type_regexp)
-      if match
-        return match[0]
+  def subtypes
+    types = []
+    text = parent_element.text
+    SUBTYPES.each do |subtype|
+      if text.include?(subtype)
+        types << subtype
       end
     end
+
+    types
   end
 end

--- a/spec/attributes/type_attribute_spec.rb
+++ b/spec/attributes/type_attribute_spec.rb
@@ -1,0 +1,33 @@
+module Bestiary
+  RSpec.describe Attributes::Type do
+    describe '#==' do
+      it 'returns true when the Types are equal' do
+        type_a = Attributes::Type.new(title: 'Foo', subtypes: %w('bar', 'baz'))
+        type_b = Attributes::Type.new(title: 'Foo', subtypes: %w('bar', 'baz'))
+
+        expect(type_a).to eq(type_b)
+      end
+
+      it 'returns false when the title is not equal' do
+        type_a = Attributes::Type.new(title: 'Bat', subtypes: %w('bar', 'baz'))
+        type_b = Attributes::Type.new(title: 'Foo', subtypes: %w('bar', 'baz'))
+
+        expect(type_a).not_to eq(type_b)
+      end
+
+      it 'returns false when a subtype is missing' do
+        type_a = Attributes::Type.new(title: 'Foo', subtypes: ['baz'])
+        type_b = Attributes::Type.new(title: 'Foo', subtypes: %w('bar', 'baz'))
+
+        expect(type_a).not_to eq(type_b)
+      end
+
+      it 'returns false when a subtypes do not match' do
+        type_a = Attributes::Type.new(title: 'Foo', subtypes: %w('dog', 'cat'))
+        type_b = Attributes::Type.new(title: 'Foo', subtypes: %w('bar', 'baz'))
+
+        expect(type_a).not_to eq(type_b)
+      end
+    end
+  end
+end

--- a/spec/parsers/type_parser_spec.rb
+++ b/spec/parsers/type_parser_spec.rb
@@ -6,10 +6,11 @@ module Bestiary
         <p class="stat-block-1">CE Large <a href="creatureTypes.html#humanoid" >humanoid</a> (giant)</p>
         HTML
         dom = parse_html(html)
+        humanoid = Attributes::Type.new(title: 'humanoid')
 
         result = Parsers::Type.perform(dom)
 
-        expect(result).to eq('humanoid')
+        expect(result).to eq(humanoid)
       end
     end
   end

--- a/spec/parsers/type_parser_spec.rb
+++ b/spec/parsers/type_parser_spec.rb
@@ -13,6 +13,21 @@ module Bestiary
         expect(result).to eq(humanoid)
       end
 
+      it 'returns the creature subtypes' do
+        html = <<-HTML
+        <p class="stat-block-1">LE Large outsider (devil, evil, extraplanar, lawful)</p>
+        HTML
+        subtypes = %w(devil evil extraplanar lawful)
+        dom = parse_html(html)
+        outsider = Attributes::Type.new(title: 'outsider',
+                                        subtypes: subtypes)
+
+        result = Parsers::Type.perform(dom)
+
+        expect(result).to eq(outsider)
+      end
+    end
+
     describe '#parent_element' do
       it 'returns the parent element of the type' do
         html = <<-HTML

--- a/spec/parsers/type_parser_spec.rb
+++ b/spec/parsers/type_parser_spec.rb
@@ -12,6 +12,20 @@ module Bestiary
 
         expect(result).to eq(humanoid)
       end
+
+    describe '#parent_element' do
+      it 'returns the parent element of the type' do
+        html = <<-HTML
+        <p class="stat-block-1">CE Large <a href="creatureTypes.html#humanoid" >humanoid</a> (giant)</p>
+        HTML
+        dom = parse_html(html)
+        stat = dom.at('p')
+        parser = Parsers::Type.new(dom)
+
+        parent = parser.parent_element
+
+        expect(parent).to eq(stat)
+      end
     end
   end
 end

--- a/spec/parsers/type_parser_spec.rb
+++ b/spec/parsers/type_parser_spec.rb
@@ -3,7 +3,7 @@ module Bestiary
     describe '.perform' do
       it 'returns the creature type' do
         html = <<-HTML
-        <p class="stat-block-1">CE Large <a href="creatureTypes.html#humanoid" >humanoid</a> (giant)</p>
+        <p class="stat-block-1">CE Large <a href="creatureTypes.html#humanoid" >humanoid</a></p>
         HTML
         dom = parse_html(html)
         humanoid = Attributes::Type.new(title: 'humanoid')

--- a/spec/parsers/type_parser_spec.rb
+++ b/spec/parsers/type_parser_spec.rb
@@ -1,0 +1,16 @@
+module Bestiary
+  RSpec.describe Parsers::Type do
+    describe '.perform' do
+      it 'returns the creature type' do
+        html = <<-HTML
+        <p class="stat-block-1">CE Large <a href="creatureTypes.html#humanoid" >humanoid</a> (giant)</p>
+        HTML
+        dom = parse_html(html)
+
+        result = Parsers::Type.perform(dom)
+
+        expect(result).to eq('humanoid')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Code and tests for the Type parser.

This now includes a Type attribute object. A type might looks like:

**Type**: `outsider`
**Subtypes**: `devil` `evil` `extraplanar` `lawful`

Eventually the goal is to store these in their own table, and reference them as foreign keys.
