### PR TITLE
Fix bug in creature parser

### DIFF
--- a/lib/bestiary/parsers/creature.rb
+++ b/lib/bestiary/parsers/creature.rb
@@ -33,7 +33,9 @@ class Bestiary::Parsers::Creature
 
   def headers
     content = dom.at('div.body')
-    content.css('h1, h2')
+    content.css('p').select do |stat|
+      stat.text.strip.match(/CR \d+\z/)
+    end
   end
 
   def heading?(element)

--- a/spec/parsers/creature_parser_spec.rb
+++ b/spec/parsers/creature_parser_spec.rb
@@ -41,7 +41,7 @@ module Bestiary
           result = Parsers::Creature.perform(dom)
 
           expect(result).to be_a(Array)
-          expect(result.count).to eq(7)
+          expect(result.count).to eq(9)
 
           result.each do |creature|
             expect(creature).to be_a(Nokogiri::HTML::DocumentFragment)


### PR DESCRIPTION
The creature parser wasn't doing its job correctly. It was searching
for h1/h2's in the document and using those as an anchor point to scan
the rest for creatures.

Now it scans all paragraphs for some amount of text plus CR X where X
is one or more digits. This is a more accurate starting point for
creatures. Combine this with also checking for a minimum number of
stats and it seems pretty reliable. We'll see if it holds up.
