### PR TITLE
Improve creature parser spec

### DIFF
--- a/lib/bestiary/parsers/creature.rb
+++ b/lib/bestiary/parsers/creature.rb
@@ -34,7 +34,7 @@ class Bestiary::Parsers::Creature
   def headers
     content = dom.at('div.body')
     content.css('p').select do |stat|
-      stat.text.strip.match(/CR\s?\d+\z/)
+      stat.text.strip.match(/CR\s?\d+(\/\d)?\Z/)
     end
   end
 

--- a/spec/fixtures/gremlin.html
+++ b/spec/fixtures/gremlin.html
@@ -1,0 +1,496 @@
+
+
+<!DOCTYPE html>
+
+<html>
+<head>
+	<meta charset = "utf-8">
+	<meta name = "viewport" content = "width=device-width, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0">
+	<title>Gremlin</title>
+	<link rel = "stylesheet" type = "text/css" href = "/pathfinderRPG/prd/include/prd-stylesheet.css" />
+	<link rel = "stylesheet" type = "text/css" href = "http://cdn.paizo.com/chrome/style/jquery.dataTables.min.css" />
+	<link rel = "stylesheet" type = "text/css" href = "http://cdn.paizo.com/chrome/style/jquery-ui.min.css" />
+</head>
+
+<body>
+
+<div class = "header">
+	<!-- Logos -->
+	<div class = "header-content">
+		<div id = "header-full">
+			<a href = "/pathfinderRPG/prd"><img src = "/pathfinderRPG/prd/include/PRD-Logo.png" alt = "Pathfinder Reference Document" style = "margin: 15px 0 0 0;" /></a>
+		</div>
+		<div id = "header-mobile">
+			<a href = "/pathfinderRPG/prd"><img src = "/pathfinderRPG/prd/include/PRD-Logo_Mobile.png" alt = "Pathfinder Reference Document" style = "margin: 5px 0 0 10px;" /></a>
+		</div>
+	</div>
+
+	<!-- Search & Navigation -->
+	<div id = "nav-menu" class = "nav-menu">
+		<a href = "#menu" class = "menu-link has-subnav"><img src = "/pathfinderRPG/prd/include/menu.png"></a>
+		<div id = "menu" class = "menu">
+			<ul>
+				<!-- Search -->
+				<li class = "search">
+					<form action = "/search" method = "get">
+						<input id = "searchBox" maxlength = "256" type = "text" name = "q" placeholder = "Search" />
+						<input type = "hidden" name = "what" value = "prd" />
+					</form>
+				</li>
+				<!-- Core Rulebook -->
+				<li class = "has-subnav">
+					<a href = "#">Core Rulebook</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/gettingStarted.html">Getting Started</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/races.html">Races</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/classes.html">Classes</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/usingSkills.html">Using Skills</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/skillDescriptions.html">Skill Descriptions</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/feats.html">Feats</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/equipment.html">Equipment</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/additionalRules.html">Additional Rules</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/combat.html">Combat</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/magic.html">Magic</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/spellLists.html">Spell Lists</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/spellIndex.html">Spell Index</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/prestigeClasses.html">Prestige Classes</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/gamemastering.html">Gamemastering</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/environment.html">Environment</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/nPCClasses.html">NPC Classes</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/creatingNPCs.html">Creating NPCs</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/magicItems.html">Magic Items</a></li>
+						<li><a href = "/pathfinderRPG/prd/coreRulebook/glossary.html">Glossary</a></li>
+					</ul>
+				</li>
+				<!-- Advanced Class Guide -->
+				<li class = "has-subnav">
+					<a href = "#">Advanced Class Guide</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/advancedClassGuide/classes/index.html">Classes</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedClassGuide/classOptions/index.html">Archetypes and Class Options</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedClassGuide/feats.html">Feats</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedClassGuide/spells/index.html">Spells</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedClassGuide/spells/spellLists.html">Spell Lists</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedClassGuide/gear/index.html">Gear and Magic Items</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedClassGuide/designingClasses.html">Designing Classes</a></li>
+					</ul>
+				</li>
+				<!-- Advanced Player's Guide -->
+				<li class = "has-subnav">
+					<a href = "#">Advanced Player's Guide</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/advancedPlayersGuide/advancedRaces.html">Races</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedPlayersGuide/advancedBaseClasses.html">Base Classes</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedPlayersGuide/advancedCoreClasses.html">Core Classes</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedPlayersGuide/advancedPrestigeClasses.html">Prestige Classes</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedPlayersGuide/advancedFeats.html">Feats</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedPlayersGuide/advancedGear.html">Gear</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedPlayersGuide/advancedSpellLists.html">Spell Lists</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedPlayersGuide/advancedSpellIndex.html">Spell Index</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedPlayersGuide/advancedMagicItems.html">Magic Items</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedPlayersGuide/advancedNewRules.html">New Rules</a></li>
+					</ul>
+				</li>
+				<!-- Advanced Race Guide -->
+				<li class = "has-subnav">
+					<a href = "#">Advanced Race Guide</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/advancedRaceGuide/coreRaces.html">Core Races</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedRaceGuide/featuredRaces.html">Featured Races</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedRaceGuide/uncommonRaces.html">Uncommon Races</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedRaceGuide/raceBuilder.html">Race Builder</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedRaceGuide/ageHeightWeight.html">Age, Height & Weight</a></li>
+						<li><a href = "/pathfinderRPG/prd/advancedRaceGuide/spellLists.html">Spell Lists</a></li>
+					</ul>
+				</li>
+				<!-- Bestiaries -->
+				<li class = "has-subnav">
+					<a href = "#">Bestiaries</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/bestiary/introduction.html">Monster Introduction</a></li>
+						<li><a href = "/pathfinderRPG/prd/indices/bestiary.html">Global Bestiary Indices</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/monsterIndex.html"><i>Bestiary</i> Monster Index</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary2/additionalMonsterIndex.html"><i>Bestiary 2</i> Monster Index</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary3/monsterIndex.html"><i>Bestiary 3</i> Monster Index</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary4/monsterIndex.html"><i>Bestiary 4</i> Monster Index</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary5/index.html"><em>Bestiary 5</em> Monster Index</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/variantMonsterIndex.html">Variant Monster Index</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/monsterCohorts.html">Monster Cohorts</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/animalCompanions.html">Animal Companions</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/monstersAsPCs.html">Monsters as PCs</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/monsterRoles.html">Monster Roles</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/encounterTables.html"><i>Bestiary</i> Encounter Tables</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/monsterCreation.html">Monster Creation</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/monsterAdvancement.html">Monster Advancement</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/universalMonsterRules.html">Universal Monster Rules</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/creatureTypes.html">Creature Types</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/monsterFeats.html">Monster Feats</a></li>
+						<!--<li><a href = "/pathfinderRPG/prd/bestiary/monstersByType.html"><i>Bestiary</i> Monsters by Type</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/monstersByCR.html"><i>Bestiary</i> Monsters by CR</a></li>
+						<li><a href = "/pathfinderRPG/prd/bestiary/monstersByTerrain.html"><i>Bestiary</i> Monsters by Terrain</a></li>-->
+					</ul>
+				</li>
+				<!-- Game Mastery Guide -->
+				<li class = "has-subnav">
+					<a href = "#">Game Mastery Guide</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/gameMasteryGuide/planarAdventures.html">Planar Adventures</a></li>
+						<li><a href = "/pathfinderRPG/prd/gameMasteryGuide/settlements.html">Settlements</a></li>
+						<li><a href = "/pathfinderRPG/prd/gameMasteryGuide/fastPlayShipCombat.html">Fast Play Ship Combat</a></li>
+						<li><a href = "/pathfinderRPG/prd/gameMasteryGuide/chases.html">Chases</a></li>
+						<li><a href = "/pathfinderRPG/prd/gameMasteryGuide/disasters.html">Disasters</a></li>
+						<li><a href = "/pathfinderRPG/prd/gameMasteryGuide/drugsAndAddiction.html">Drugs and Addiction</a></li>
+						<li><a href = "/pathfinderRPG/prd/gameMasteryGuide/haunts.html">Haunts</a></li>
+						<li><a href = "/pathfinderRPG/prd/gameMasteryGuide/hazards.html">Hazards</a></li>
+						<li><a href = "/pathfinderRPG/prd/gameMasteryGuide/sanityAndMadness.html">Sanity and Madness</a></li>
+						<li><a href = "/pathfinderRPG/prd/gameMasteryGuide/nPCBoons.html">NPC Boons</a></li>
+						<li><a href = "/pathfinderRPG/prd/gameMasteryGuide/nPCGallery.html">NPC Gallery</a></li>
+					</ul>
+				</li>
+				<!-- Monster Codex -->
+				<li class = "has-subnav">
+					<a href = "#">Monster Codex</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/boggards.html">Boggards</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/bugbears.html">Bugbears</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/drow.html">Drow</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/duergar.html">Duergar</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/fireGiants.html">Fire Giants</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/frostGiants.html">Frost Giants</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/ghouls.html">Ghouls</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/gnolls.html">Gnolls</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/goblins.html">Goblins</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/hobgoblins.html">Hobgoblins</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/kobolds.html">Kobolds</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/lizardfolk.html">Lizardfolk</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/ogres.html">Ogres</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/orcs.html">Orcs</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/ratfolk.html">Ratfolk</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/sahuagin.html">Sahuagin</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/serpentfolk.html">Serpentfolk</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/troglodytes.html">Troglodytes</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/trolls.html">Trolls</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/vampires.html">Vampires</a></li>
+						<li><a href = "/pathfinderRPG/prd/monsterCodex/appendix.html">Modifying Monsters</a></li>
+					</ul>
+				</li>
+				<!-- Mythic Adventures -->
+				<li class = "has-subnav">
+					<a href = "#">Mythic Adventures</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/mythicAdventures/Glossary.html">Glossary</a></li>
+						<li><a href = "/pathfinderRPG/prd/mythicAdventures/mythicHeroes.html">Mythic Heroes</a></li>
+						<li><a href = "/pathfinderRPG/prd/mythicAdventures/mythicFeats.html">Mythic Feats</a></li>
+						<li><a href = "/pathfinderRPG/prd/mythicAdventures/mythicSpells.html">Mythic Spells</a></li>
+						<li><a href = "/pathfinderRPG/prd/mythicAdventures/mythicSpells/spellIndex.html">Mythic Spell Index</a></li>
+						<li><a href = "/pathfinderRPG/prd/mythicAdventures/mythicSpells/spellLists.html">Mythic Spell Lists</a></li>
+						<li><a href = "/pathfinderRPG/prd/mythicAdventures/mythicGame.html">Running a Mythic Game</a></li>
+						<li><a href = "/pathfinderRPG/prd/mythicAdventures/mythicItems.html">Mythic Magic Items</a></li>
+						<li><a href = "/pathfinderRPG/prd/mythicAdventures/mythicMonsters.html">Mythic Monsters</a></li>
+					</ul>
+				</li>
+				<!-- NPC Codex -->
+				<li class = "has-subnav">
+					<a href = "#">NPC Codex</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/npcCodex/core/index.html">Core Classes</a></li>
+						<li><a  href = "/pathfinderRPG/prd/npcCodex/prestige/index.html">Prestige Classes</a></li>
+						<li><a href = "/pathfinderRPG/prd/npcCodex/npc/index.html">NPC Classes</a></li>
+						<li><a href = "/pathfinderRPG/prd/npcCodex/appendix.html">Appendix</a></li>
+					</ul>
+				</li>
+				<!-- Pathfinder Unchained -->
+				<li class = "has-subnav">
+					<a href = "#">Pathfinder Unchained</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/unchained/classes/index.html">Classes</a></li>
+						<li><a href = "/pathfinderRPG/prd/unchained/skillsAndOptions/index.html">Skills and Options</a></li>
+						<li><a href = "/pathfinderRPG/prd/unchained/gameplay/index.html">Gameplay</a></li>
+						<li><a href = "/pathfinderRPG/prd/unchained/magic/index.html">Magic</a></li>
+						<li><a href = "/pathfinderRPG/prd/unchained/monsters/index.html">Monsters</a></li>
+					</ul>
+				</li>
+				<!-- Occult Adventures -->
+				<li class = "has-subnav">
+					<a href = "#">Occult Adventures</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/occultAdventures/classes/index.html">Occult Classes</a></li>
+						<li><a href = "/pathfinderRPG/prd/occultAdventures/archetypes/index.html">Archetypes</a></li>
+						<li><a href = "/pathfinderRPG/prd/occultAdventures/feats.html">Feats</a></li>
+						<li><a href = "/pathfinderRPG/prd/occultAdventures/psychicMagic.html">Psychic Magic</a></li>
+						<li><a href = "/pathfinderRPG/prd/occultAdventures/spellLists.html">Spell Lists</a></li>
+						<li><a href = "/pathfinderRPG/prd/occultAdventures/spells/index.html">Spells</a></li>
+						<li><a href = "/pathfinderRPG/prd/occultAdventures/occultRules.html">Occult Rules</a></li>
+						<li><a href = "/pathfinderRPG/prd/occultAdventures/occultGame.html">Running an Occult Game</a></li>
+						<li><a href = "/pathfinderRPG/prd/occultAdventures/occultRewards.html">Occult Rewards</a></li>
+					</ul>
+				</li>
+				<!-- Ultimate Campaign -->
+				<li class = "has-subnav">
+					<a href = "#">Ultimate Campaign</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/ultimateCampaign/characterBackground.html">Character Background</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateCampaign/downtime.html">Downtime</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateCampaign/campaignSystems.html">Campaign Systems</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateCampaign/kingdomsAndWar.html">Kingdoms and War</a></li>
+					</ul>
+				</li>
+				<!-- Ultimate Combat -->
+				<li class = "has-subnav">
+					<a href = "#">Ultimate Combat</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/ultimateCombat/classes/gunslinger.html">Gunslinger</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateCombat/classes/ninja.html">Ninja</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateCombat/classes/samurai.html">Samurai</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateCombat/classArchetypes.html">Class Archetypes</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateCombat/ultimateCombatFeats.html">Feats</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateCombat/combat/introduction.html">Mastering Combat</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateCombat/ultimateCombatVehicles.html">Vehicles</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateCombat/variants/introduction.html">Variant Rules</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateCombat/ultimateCombatSpellIndex.html">Spell Index</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateCombat/ultimateCombatSpellLists.html">Spell Lists</a></li>
+					</ul>
+				</li>
+				<!-- Ultimate Equipment -->
+				<li class = "has-subnav">
+					<a href = "#">Ultimate Equipment</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/ultimateEquipment/armsAndArmor/index.html">Arms and Armor</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateEquipment/gear/index.html">Gear</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateEquipment/magicArmsAndArmor/index.html">Magic Arms and Armor</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateEquipment/ringsRodsStaves/index.html">Rings, Rods, and Staves</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateEquipment/wondrousItems/index.html">Wondrous Items</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateEquipment/artifactsAndOthers/index.html">Artifacts and Other Items</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateEquipment/appendix.html">Appendix</a></li>
+					</ul>
+				</li>
+				<!-- Ultimate Magic -->
+				<li class = "has-subnav">
+					<a href = "#">Ultimate Magic</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/ultimateMagic/spellcasters/magus.html">Magus</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateMagic/spellcastingClassOptions.html">Spellcasting Class Options</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateMagic/magic/introduction.html">Mastering Magic</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateMagic/ultimateMagicFeats.html">Feats</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateMagic/ultimateMagicWordsOfPower.html">Words of Power</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateMagic/ultimateMagicSpellIndex.html">Spells</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateMagic/ultimateMagicSpellLists.html">Spell Lists</a></li>
+						<li><a href = "/pathfinderRPG/prd/ultimateMagic/ultimateMagicAppendices.html">Updates</a></li>
+					</ul>
+				</li>
+				<!-- Technology Guide -->
+				<li class = "has-subnav">
+					<a href = "#">Technology Guide</a>
+					<ul class = "level-2">
+						<li class = "has-subnav">
+							<a href = "#" style = "padding-left: 20px;">Technology in the World</a>
+							<ul class = "level-3">
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/skills.html">Skills</a></li>
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/feats.html">Feats</a></li>
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/spells.html">Spells</a></li>
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/archetypes.html">Archetypes</a></li>
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/technomancer.html">Technomancer</a></li>
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/crafting.html">Crafting</a></li>
+							</ul>
+						</li>
+						<li class = "has-subnav">
+							<a href = "#" style = "padding-left: 20px;">Equipment</a>
+							<ul class = "level-3">
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/equipmentIntroduction.html">Introduction</a></li>
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/weapons.html">Weapons</a></li>
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/armor.html">Armor</a></li>
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/pharmaceuticals.html">Pharmaceuticals</a></li>
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/cybertech.html">Cybertech</a></li>
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/gear.html">Gear</a></li>
+							</ul>
+						</li>
+						<li class = "has-subnav">
+							<a href = "#" style = "padding-left: 20px;">Hazards and Artifacts</a>
+							<ul class = "level-3">
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/hazards.html">Hazards</a></li>
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/ai.html">Artificial Intelligences</a></li>
+								<li><a href = "/pathfinderRPG/prd/technologyGuide/artifacts.html">Artifacts</a></li>
+							</ul>
+						</li>
+					</ul>
+				</li>
+				<!-- Index -->
+				<li class = "has-subnav">
+					<a href = "#">Index</a>
+					<ul class = "level-2">
+						<li><a href = "/pathfinderRPG/prd/indices/bestiary.html">Bestiary Index</a></li>
+						<li><a href = "/pathfinderRPG/prd/indices/feats.html">Feats Index</a></li>
+						<!--<li><a href = "/pathfinderRPG/prd/indices/spells.html">Spell Index</a></li>-->
+						<li><a href = "/pathfinderRPG/prd/indices/spelllists.html">Spell List Index</a></li>
+						<li><a href = "/pathfinderRPG/prd/indices/templates.html">Template Index</a></li>
+					</ul>
+				</li>
+				<!-- OGL -->
+				<li>
+					<a href = "/pathfinderRPG/prd/openGameLicense.html">Open Game License</a>
+				</li>
+				<!-- Report a Problem -->
+				<li>
+					<a href = "/threads/rzs2soys">Report a Problem</a>
+				</li>
+			</ul>
+		</div>
+	</div>
+</div>
+
+<div class = "body-content">
+
+	<div id = "nav-path"></div>
+
+	<div class = "body">
+
+
+
+<h1 id="gremlin-grimple" class="monster-header">Gremlin, Grimple</h1>
+<p class = "flavor-text">This putrid-looking humanoid bears a disquieting resemblance to a half-starved, mange-ridden opossum.</p>
+
+<p class = "stat-block-title">Grimple <span class = "stat-block-cr">CR 1/3</span></p>
+<p class = "stat-block-xp">XP 135</p>
+<p class = "stat-block-1">CN Tiny fey</p>
+<p class = "stat-block-1"><b>Init</b> +1; <b>Senses</b> low-light vision; <a href="/pathfinderRPG/prd/coreRulebook/skills/perception.html#perception" >Perception</a> +4</p>
+<p class = "stat-block-breaker">Defense</p>
+<p class = "stat-block-1"><b>AC</b> 13, touch 13, flat-footed 12 (+1 Dex, +2 size)</p>
+<p class = "stat-block-1"><b>hp</b> 4 (1d6+1)</p>
+<p class = "stat-block-1"><b>Fort</b> +1, <b>Ref</b> +3, <b>Will</b> +2</p>
+<p class = "stat-block-1"><b>DR</b> 2/cold iron</p>
+<p class = "stat-block-breaker">Offense</p>
+<p class = "stat-block-1"><b>Speed</b> 20 ft., climb 20 ft., fly 20 ft. (clumsy)</p>
+<p class = "stat-block-1"><b>Melee</b> bite +3 (1d3–4)</p>
+<p class = "stat-block-1"><b>Ranged</b> rock +3 (1d2–4)</p>
+<p class = "stat-block-1"><b>Space</b> 2-1/2 ft.; <b>Reach</b> 0 ft.</p>
+<p class = "stat-block-1"><b>Special Attacks</b> putrid vomit</p>
+<p class = "stat-block-1"><b>Spell-Like Abilities</b> (CL 1st; concentration –1)</p>
+<p class = "stat-block-2">At will&mdash;<i><a href="/pathfinderRPG/prd/coreRulebook/spells/prestidigitation.html#prestidigitation" >prestidigitation</a></i></p>
+<p class = "stat-block-2">3/day&mdash;<i><a href="/pathfinderRPG/prd/coreRulebook/spells/grease.html#grease" >grease</a></i> (DC 9), <i><a href="/pathfinderRPG/prd/coreRulebook/spells/mageHand.html#mage-hand" >mage hand</a></i>, <i><a href="/pathfinderRPG/prd/coreRulebook/spells/openClose.html#open-close" >open/close</a></i></p>
+<p class = "stat-block-breaker">Statistics</p>
+<p class = "stat-block-1"><b>Str</b> 3, <b>Dex</b> 13, <b>Con</b> 12, <b>Int</b> 10, <b>Wis</b> 11, <b>Cha</b> 6</p>
+<p class = "stat-block-1"><b>Base Atk </b>+0; <b>CMB</b> –1; <b>CMD</b> 5</p>
+<p class = "stat-block-1"><b>Feats</b> Skill Focus (<a href="/pathfinderRPG/prd/coreRulebook/skills/stealth.html#stealth" >Stealth</a>), Weapon Finesse<sup>B</sup></p>
+<p class = "stat-block-1"><b>Skills</b> <a href="/pathfinderRPG/prd/coreRulebook/skills/climb.html#climb" >Climb</a> +13, <a href="/pathfinderRPG/prd/coreRulebook/skills/fly.html#fly" >Fly</a> +1, <a href="/pathfinderRPG/prd/coreRulebook/skills/perception.html#perception" >Perception</a> +4, <a href="/pathfinderRPG/prd/coreRulebook/skills/sleightOfHand.html#sleight-of-hand" >Sleight of Hand</a> +5, <a href="/pathfinderRPG/prd/coreRulebook/skills/stealth.html#stealth" >Stealth</a> +16, <a href="/pathfinderRPG/prd/coreRulebook/skills/swim.html#swim" >Swim</a> +5</p>
+<p class = "stat-block-1"><b>Languages</b> Undercommon</p>
+<p class = "stat-block-1"><b>SQ</b> gremlin lice</p>
+<p class = "stat-block-breaker">Ecology</p>
+<p class = "stat-block-1"><b>Environment</b> any urban</p>
+<p class = "stat-block-1"><b>Organization</b> solitary, pair, mob (3–8), or infestation (9–16 plus 2–6 trained dire rats and 1–4 spider swarms)</p>
+<p class = "stat-block-1"><b>Treasure</b> standard</p>
+<p class = "stat-block-breaker">Special Abilities</p>
+<p class = "stat-block-1"><b>Gremlin Lice (Ex) </b>All grimples are infested with gremlin lice. Whenever a warm-blooded creature comes in physical contact with a grimple, there is a 25% chance it contracts gremlin lice. 1d4 rounds later, the creature begins to itch. The itch proves so distracting that for the duration of the infestation, the individual takes a –1 penalty on all concentration and initiative checks. Fortunately, these annoying parasites cannot live long on non-gremlins, and only survive for 24 hours. Submersion in water or exposure to freezing temperatures also kills a gremlin lice infestation.</p>
+<p class = "stat-block-1"><b>Putrid Vomit (Ex)</b> Every 1d4 rounds, a grimple can spew a 30-foot line of vomit as a standard action. Treat this as a ranged touch attack with no range increment. Anyone struck must succeed at a DC 11 Fortitude save or be nauseated for 1d4 rounds. The save DC is Constitution-based.</p>
+<p>Grimples are filthy urban scavengers that lurk beneath the eaves of abandoned buildings, clock towers, belfries, and steeples. Sickly-looking and ragged, they shed constantly as a result of the small parasites they host. Quick climbers, grimples also have loose flaps of skin that stretch between their arms and allow them to glide short distances.</p>
+<p>Grimples despise humans and show it by attacking drunks, unlocking stables, torturing guard dogs, and loosening hanging storefront signs so that they fall on people. This does not stop them from sometimes allying with humans and other humanoids, but such collaborations are always temporary, as a grimple is ever plotting betrayal. Although a grimple is often arrogant and overbearing, its ability to vomit at will (and propensity for doing so constantly) remains its most unappealing quality.</p>
+<p>Voracious omnivores, grimples feast off garbage. They frequently target inns, restaurants, and other places where they can scavenge a steady supply of food.</p>
+
+
+<h1 id="gremlin-haniver" class="monster-header">Gremlin, Haniver</h1>
+<p class = "flavor-text">This small, bizarre humanoid creature has finlike wings, strange yellow skin, and tiny black eyes burning with malevolence.</p>
+
+<p class = "stat-block-title">Haniver <span class = "stat-block-cr">CR 1/2</span></p>
+<p class = "stat-block-xp">XP 200</p>
+<p class = "stat-block-1">N Tiny fey (aquatic)</p>
+<p class = "stat-block-1"><b>Init</b> +5; <b>Senses</b> darkvision 60 ft., low-light vision; <a href="/pathfinderRPG/prd/coreRulebook/skills/perception.html#perception" >Perception</a> +4</p>
+<p class = "stat-block-breaker">Defense</p>
+<p class = "stat-block-1"><b>AC</b> 13, touch 13, flat-footed 12 (+1 Dex, +2 size)</p>
+<p class = "stat-block-1"><b>hp</b> 4 (1d6+1)</p>
+<p class = "stat-block-1"><b>Fort</b> +1, <b>Ref</b> +3, <b>Will</b> +2</p>
+<p class = "stat-block-1"><b>DR</b> 2/cold iron; <b>SR</b> 11</p>
+<p class = "stat-block-breaker">Offense</p>
+<p class = "stat-block-1"><b>Speed</b> 10 ft., fly 20 ft. (average), swim 20 ft.</p>
+<p class = "stat-block-1"><b>Melee</b> bite +1 (1d3–1)</p>
+<p class = "stat-block-1"><b>Space</b> 2-1/2 ft.; <b>Reach</b> 0 ft.</p>
+<p class = "stat-block-1"><b>Special Attacks</b> misplacement</p>
+<p class = "stat-block-1"><b>Spell-Like Abilities</b> (CL 1st; concentration +2)</p>
+<p class = "stat-block-1">At will&mdash;<i><a href="/pathfinderRPG/prd/coreRulebook/spells/prestidigitation.html#prestidigitation" >prestidigitation</a></i>, <i><a href="/pathfinderRPG/prd/coreRulebook/spells/ventriloquism.html#ventriloquism" >ventriloquism</a></i> (DC 12)</p>
+<p class = "stat-block-1">1/day&mdash;<i><a href="/pathfinderRPG/prd/coreRulebook/spells/scare.html#scare" >scare</a></i> (DC 13)</p>
+<p class = "stat-block-breaker">Statistics</p>
+<p class = "stat-block-1"><b>Str</b> 9, <b>Dex</b> 13, <b>Con</b> 12, <b>Int</b> 8, <b>Wis</b> 11, <b>Cha</b> 12</p>
+<p class = "stat-block-1"><b>Base Atk</b> +0; <b>CMB</b> –1; <b>CMD</b> 8</p>
+<p class = "stat-block-1"><b>Feats</b> Improved Initiative</p>
+<p class = "stat-block-1"><b>Skills</b> <a href="/pathfinderRPG/prd/coreRulebook/skills/disableDevice.html#disable-device" >Disable Device</a> +3, <a href="/pathfinderRPG/prd/coreRulebook/skills/disguise.html#disguise" >Disguise</a> +5, <a href="/pathfinderRPG/prd/coreRulebook/skills/fly.html#fly" >Fly</a> +5, <a href="/pathfinderRPG/prd/coreRulebook/skills/perception.html#perception" >Perception</a> +4, <a href="/pathfinderRPG/prd/coreRulebook/skills/sleightOfHand.html#sleight-of-hand" >Sleight of Hand</a> +7, <a href="/pathfinderRPG/prd/coreRulebook/skills/stealth.html#stealth" >Stealth</a> +13, <a href="/pathfinderRPG/prd/coreRulebook/skills/swim.html#swim" >Swim</a> +11; <b>Racial Modifiers</b> +2 <a href="/pathfinderRPG/prd/coreRulebook/skills/disableDevice.html#disable-device" >Disable Device</a>, +2 <a href="/pathfinderRPG/prd/coreRulebook/skills/sleightOfHand.html#sleight-of-hand" >Sleight of Hand</a></p>
+<p class = "stat-block-1"><b>Languages</b> Common, Sylvan</p>
+<p class = "stat-block-1"><b>SQ</b> amphibious</p>
+<p class = "stat-block-breaker">Ecology</p>
+<p class = "stat-block-1"><b>Environment</b> temperate coasts</p>
+<p class = "stat-block-1"><b>Organization</b> solitary, pair, or swarm (4–12)</p>
+<p class = "stat-block-1"><b>Treasure</b> incidental</p>
+<p class = "stat-block-breaker">Special Abilities</p>
+<p class = "stat-block-1"><b>Misplacement (Su)</b> Hanivers are swift and curious, possessing an uncanny ability to meddle with the possessions of any character whose square they enter. Any time a haniver succeeds at a <a href="/pathfinderRPG/prd/coreRulebook/skills/sleightOfHand.html#sleight-of-hand" >Sleight of Hand</a> check against a creature, it also rearranges that creature's possessions. The next time that creature attempts to produce a weapon or item, it finds its possessions misplaced or disarranged; retrieving a stored item or drawing a weapon then requires a standard action instead of a move action (unless the haniver has stolen the item in question). After spending this standard action, the character takes mental inventory and is no longer affected by this ability.</p>
+<p class = "stat-block-1">Occasionally, hanivers replace items they've stolen or leave their old treasures&mdash;seashells, old fish, clumps of sand&mdash;in containers or clothing they have rooted through. They do this without any added difficultly to their <a href="/pathfinderRPG/prd/coreRulebook/skills/sleightOfHand.html#sleight-of-hand" >Sleight of Hand</a> checks.</p>
+
+<p>Haniver gremlins haunt the stories of sailors and fishing communities, featuring prominently in parables told to naughty children by disapproving parents. A thousand such tales exist, each a variation on a common theme&mdash;the gremlins flap up from the sea, startle nasty fishermen or disobedient youths, and make off with their trinkets. Yet as is rarely the case with such tales, nearly every word of these stories&mdash;no matter how unlikely or comic&mdash;proves near to the truth.</p>
+<p>Strange, capricious fey creatures that enjoy skimming whitecaps, flipping over solitary horseshoe crabs, and suicidally teasing dolphins and sharks, hanivers endlessly indulge a mad racial curiosity. Such is their obsession that every haniver must know what is under every rock, in every basket, and beneath every hat. Should they like what they find, they typically attempt to make off with it, clinging to their prize like a beloved heirloom until the next curiosity or shiny treasure catches their attention. Hanivers have no concept of worth, though they know much of desirability, and might hang onto an item they would otherwise discard in moments if another creature&mdash;or former owner&mdash;expresses desire for it. The gremlins don't steal out of any sense of maliciousness, but rather out of curiosity and selfishness. The most intelligent occasionally even believe that they're trading, and leave behind old "treasures"&mdash;often strange or natural items that barely fit the description&mdash;in place of things they've claimed. Regardless, folklore advises those who have something stolen by a haniver to simply abandon it rather than face the frustration of attempting to rescue it&mdash;hence the tendency of sailors to blame the hanivers whenever something goes missing.</p>
+<p>Hanivers possess flat, leathery bodies with only a few thin bones. Most stand little more than a foot tall and 1-1/2 feet across, and weigh less than 5 pounds.</p>
+
+
+<h1 id="gremlin-monaciello" class="monster-header">Gremlin, Monaciello</h1>
+<p class = "flavor-text">Dressed in red robes like those of a monk, this little monster displays a sharp-toothed smile and flips a gold coin in its hand.</p>
+
+<p class = "stat-block-title">Monaciello <span class = "stat-block-cr">CR 1</span></p>
+<p class = "stat-block-xp">XP 400</p>
+<p class = "stat-block-1">CE Small fey</p>
+<p class = "stat-block-1"><b>Init</b> +2; <b>Senses</b> low-light vision; <a href="/pathfinderRPG/prd/coreRulebook/skills/perception.html#perception" >Perception</a> +6</p>
+<p class = "stat-block-1"><b>Aura</b> stymie channeling (20 ft.; DC 12)</p>
+<p class = "stat-block-breaker">Defense</p>
+<p class = "stat-block-1"><b>AC</b> 13, touch 13, flat-footed 11 (+2 Dex, +1 size)</p>
+<p class = "stat-block-1"><b>hp</b> 14 (2d6+7)</p>
+<p class = "stat-block-1"><b>Fort</b> +2, <b>Ref</b> +5, <b>Will</b> +4; +4 vs. divine magic</p>
+<p class = "stat-block-1"><b>DR</b> 5/cold iron; <b>SR</b> 12</p>
+<p class = "stat-block-breaker">Offense</p>
+<p class = "stat-block-1"><b>Speed</b> 30 ft.</p>
+<p class = "stat-block-1"><b>Melee</b> bite +4 (1d4–2), dagger +4 (1d3–2/19–20)</p>
+<p class = "stat-block-1"><b>Spell-Like Abilities</b> (CL 3rd; concentration +4)</p>
+<p class = "stat-block-2">At will&mdash;<i><a href="/pathfinderRPG/prd/coreRulebook/spells/prestidigitation.html#prestidigitation" >prestidigitation</a></i>, <i><a href="/pathfinderRPG/prd/advancedPlayersGuide/spells/putrefyFoodAndDrink.html#putrefy-food-and-drink" >putrefy food and drink</a> </i>(DC 11), <i><a href="/pathfinderRPG/prd/coreRulebook/spells/ghostSound.html#ghost-sound" >ghost sound</a></i> (DC 12), <i><a href="/pathfinderRPG/prd/coreRulebook/spells/silentImage.html#silent-image" >silent image</a></i> (DC 12)</p>
+<p class = "stat-block-2">1/day&mdash;<i><a href="/pathfinderRPG/prd/coreRulebook/spells/glitterdust.html#glitterdust" >glitterdust</a></i></p>
+<p class = "stat-block-breaker">Statistics</p>
+<p class = "stat-block-1"><b>Str</b> 6, <b>Dex</b> 15, <b>Con</b> 14, <b>Int</b> 11, <b>Wis</b> 12, <b>Cha</b> 13</p>
+<p class = "stat-block-1"><b>Base</b> <b>Atk</b> +1; <b>CMB</b> –2; <b>CMD</b> 10</p>
+<p class = "stat-block-1"><b>Feats</b> Skill Focus (<a href="/pathfinderRPG/prd/coreRulebook/skills/stealth.html#stealth" >Stealth</a>), Toughness<sup>B</sup>, Weapon Finesse<sup>B</sup></p>
+<p class = "stat-block-1"><b>Skills</b> <a href="/pathfinderRPG/prd/coreRulebook/skills/bluff.html#bluff" >Bluff</a> +6, <a href="/pathfinderRPG/prd/coreRulebook/skills/disableDevice.html#disable-device" >Disable Device</a> +8, <a href="/pathfinderRPG/prd/coreRulebook/skills/escapeArtist.html#escape-artist" >Escape Artist</a> +7, <a href="/pathfinderRPG/prd/coreRulebook/skills/perception.html#perception" >Perception</a> +6, <a href="/pathfinderRPG/prd/coreRulebook/skills/senseMotive.html#sense-motive" >Sense Motive</a> +6, <a href="/pathfinderRPG/prd/coreRulebook/skills/stealth.html#stealth" >Stealth</a> +18 (+14 when moving); <b>Racial Modifiers</b> +4 <a href="/pathfinderRPG/prd/coreRulebook/skills/disableDevice.html#disable-device" >Disable Device</a>, +4 <a href="/pathfinderRPG/prd/coreRulebook/skills/stealth.html#stealth" >Stealth</a> (+0 when moving)</p>
+<p class = "stat-block-1"><b>Languages</b> Aklo</p>
+<p class = "stat-block-1"><b>SQ</b> compression, magic bag</p>
+<p class = "stat-block-breaker">Ecology</p>
+<p class = "stat-block-1"><b>Environment</b> any urban</p>
+<p class = "stat-block-1"><b>Organization</b> solitary, pair, congregation (3–12), or infestation (13–20 plus 1–3 sorcerers of 1st–3rd level, 1 rogue leader of 2nd–4th level, 2–14 trained dire rats, 2–5 trained venomous snakes, and 1–3 rat swarms)</p>
+<p class = "stat-block-1"><b>Treasure</b> double (always gold coins)</p>
+<p class = "stat-block-breaker">Special Abilities</p>
+<p class = "stat-block-1"><b>Magic Bag (Su)</b> A monaciello always carries its pouch with it. This pouch contains an extradimensional space and operates like a <i>bag</i> <i>of</i> <i>holding </i>(type I). If this pouch is separated from the monaciello, all of its former contents are lost, and it becomes a normal bag that contains a number of coins equal to double the treasure value of a creature of the gremlin's CR. A monaciello that loses its pouch must create a new one, a process that takes 1d4 days. Until the new pouch is finished, it remains a non-magical bag, only becoming a fully functional extradimensional space once completed.</p>
+<p class = "stat-block-1"><b>Stymie Channeling (Su)</b> A monaciello gremlin is surrounded by an aura of blasphemy. Any creatures channeling energy within 20 feet of a monaciello must succeed at a DC 12 Will save or be unable to channel for that round. The use is not lost, but the action is wasted.</p>
+
+<p>Most often found in urban environments, this gremlin lives among humanity, taunting religious and scholarly organizations with its pranks. Monaciello gremlins are most commonly found in monasteries and cathedrals where they wriggle their way up from the sewers and catacombs to play tricks on the devout.</p>
+<p>These tricksters pull blankets off sleeping clergy members, harass servants, spoil food, and hide valuables from their owners. Enamored with gold, they often overinflate the value of things with illusions, and even throw handfuls of gold coins (or illusions of gold coins if they are feeling especially stingy) to distract creatures on their trail. They pull these coins from their ever-present magical bags, confident they can always pilfer more.</p>
+<p>A monaciello stands 2-1/2 feet tall and weighs approximately 20 pounds.</p>
+
+
+</div>
+	<div class = "footer">
+		<p>
+			<a href = "/threads/rzs2soys">Report a Problem</a><br /><br />
+			&copy;2002-2016 Paizo, Inc.&reg;<br />
+			Paizo Inc., Paizo, Pathfinder, and the Pathfinder logo are registered trademarks of Paizo Inc., and<br />
+			Pathfinder Roleplaying Game and Pathfinder Campaign Setting are trademarks of Paizo Inc.<br />
+			<a href="/pathfinderRPG/prd/openGameLicense.html">Open Game License</a>.
+		</p>
+	</div>
+
+	</div>
+</div>
+
+<script type = "text/javascript" src = "/pathfinderRPG/prd/include/js/jquery-1.10.2.min.js"></script>
+<script type = "text/javascript" src = "/pathfinderRPG/prd/include/js/jquery.cookie.js"></script>
+<script type = "text/javascript" src = "http://cdn.paizo.com/chrome/js/jquery.dataTables.min.js"></script>
+<script type = "text/javascript" src = "/pathfinderRPG/prd/include/js/prd-jquery.js"></script>
+<script type = "text/javascript" src = "/pathfinderRPG/prd/include/js/prd-scripts.js"></script>
+<script type = "text/javascript">var globalTitle="Gremlin",globalNavPath=[{ href: '/pathfinderRPG/prd/bestiary4/monsterIndex.html', name: 'Bestiary 4 Index'}];</script>
+<script type = "text/javascript">
+$(function () {
+	if(!/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+			highlightNavLocation(globalNavPath);
+		}
+	});
+</script>
+</body>
+</html>

--- a/spec/parsers/creature_parser_spec.rb
+++ b/spec/parsers/creature_parser_spec.rb
@@ -63,6 +63,22 @@ module Bestiary
             end
           end
         end
+
+        context 'when the challenge rating is a fraction' do
+          it 'returns DocumentFragments in an array' do
+            html = fixture_load('gremlin.html')
+            dom = parse_html(html)
+
+            result = Parsers::Creature.perform(dom)
+
+            expect(result).to be_a(Array)
+            expect(result.count).to eq(3)
+
+            result.each do |creature|
+              expect(creature).to be_a(Nokogiri::HTML::DocumentFragment)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Since switching to scanning for headers with CR in them, I didn't
account for creatures that have a fractional challenge rating like 1/2
or 1/3.

The parser checks for "CR", an optional space, and multiple digits. Now
it also checks for an optional "/" then digit such as /3 or /2.
Finally, it checks for the end of the line.